### PR TITLE
WD-134-in-backend-migration-request-api-change-made-the-email-body-if-the-total-requested-users-is-greater-than-100

### DIFF
--- a/src/helpers/SesMail.ts
+++ b/src/helpers/SesMail.ts
@@ -62,6 +62,11 @@ const emailTemplate = (
   toUserDetails: MicrosoftUser,
   origin?: string
 ) => {
+  const actualReporteesLength = reportees.length;
+  if (reportees.length > 100) {
+    reportees = reportees.slice(0, 100);
+  }
+
   return `<body>
   
   <style>
@@ -158,6 +163,13 @@ const emailTemplate = (
           return total;
         }, "")}
       </table>`
+      : ``
+  }
+  ${
+    actualReporteesLength > 100
+      ? `<div>
+    <p>+ ${actualReporteesLength - 100} items left </p>
+    </div>`
       : ``
   }
   ${

--- a/src/routers/microsoftUser.router.ts
+++ b/src/routers/microsoftUser.router.ts
@@ -338,12 +338,12 @@ router.post(
       //Below userId is not used currenlty It will be used for the future Authorization and Authentication purpose
       const userId = req.params.userId;
       const toUser = req.body.toUser;
-      const reportees = req.body.reportees;
+      const requestReporteeIds = req.body.reportees;
       const origin: string | undefined = req.headers.origin;
 
       const response = await requestReporteesMigration(
         toUser,
-        reportees,
+        requestReporteeIds,
         origin!
       );
       if (response.code === 200) {


### PR DESCRIPTION
### Summary
Changes in backend migration Request API, Made only 100 users to be visible in the table format in the mail and others are noted in numbers

### What are the changes?
- Get only the userIds from Frontend instead of userObject.
- Get all the userDetails by userIds.
-  Made only 100 users to be visible in the table format in the mail and others are noted in numbers.


Please check your PR against the following requirements and update the check state accordingly.

- [ ] Does this PR includes any breaking changes.
- [X] Have you self-reviewed this PR on context with the previous PR changes.
